### PR TITLE
Allow "bpr.coding" to be a source

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcoder
 Type: Package
 Title: Lightweight Data Structure for Recoding Categorical Data without Factors
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: 
     c(person(
             given = "Patrick", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rcoder 0.1.3
+
+* Allows "bpr.coding" attributes to be suitable sources for recoding if "rcoder.coding" is not defined
+
 # rcoder 0.1.2
 
 * Adds {blueprintr} variable decoration support during assigning coding or recoding of vectors

--- a/man/recode_vec.Rd
+++ b/man/recode_vec.Rd
@@ -4,13 +4,7 @@
 \alias{recode_vec}
 \title{Recode a vector}
 \usage{
-recode_vec(
-  vec,
-  to,
-  from = get_attr(vec, "rcoder.coding"),
-  .embed = TRUE,
-  .bpr = TRUE
-)
+recode_vec(vec, to, from = NULL, .embed = TRUE, .bpr = TRUE)
 }
 \arguments{
 \item{vec}{A vector}
@@ -18,7 +12,9 @@ recode_vec(
 \item{to}{A coding object to which the vector will be recoded}
 
 \item{from}{A coding object that describes the current coding
-of the vector. Defaults to the "rcoder.coding" attribute value}
+of the vector. Defaults to the "rcoder.coding" attribute value, if
+it exists, _or_ the "bpr.coding" value (from blueprintr). If neither
+are found, `from` stays `NULL` and the function errors.}
 
 \item{.embed}{If `TRUE`, `from` will be stored in the "rcoder.coding"
 attribute}

--- a/tests/testthat/test-recoding.R
+++ b/tests/testthat/test-recoding.R
@@ -70,7 +70,7 @@ test_that("Vector recoding works", {
   set.seed(9001)
 
   vec <- sample(0:3, 20, replace = TRUE)
-  expect_null(get_attr(vec, "rcoder.coding"))
+  expect_null(get_vector_attrib(vec))
 
   coding_1 <- coding(
     code("Never", 0),
@@ -79,6 +79,14 @@ test_that("Vector recoding works", {
     code("Frequently", 3)
   )
 
+  # Allows "bpr.coding" to be used as a suitable source
+  vec2 <- sample(0:3, 20, replace = TRUE)
+  vec2 <- set_attrs(
+    vec2,
+    bpr.coding = as.character(coding_1)
+  )
+  expect_identical(get_vector_attrib(vec2), coding_1)
+  
   expect_error(recode_vec(vec, to = coding_1))
 
   vec <- assign_coding(vec, coding_1)


### PR DESCRIPTION
Minor feature that allows "bpr.coding" attributes, from {blueprintr}, to be used as a source for `recode_vec`. Also changes the default value of `from` in `recode_vec` to be `NULL` since `get_attr()` is not an exported function.