### PR TITLE
Improve linking error message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcoder
 Type: Package
 Title: Lightweight Data Structure for Recoding Categorical Data without Factors
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: 
     c(person(
             given = "Patrick", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rcoder 0.1.4
+
+* Adds `to` and `from` members to incomplete linking error object for end-user diagnostics
+
 # rcoder 0.1.3
 
 * Allows "bpr.coding" attributes to be suitable sources for recoding if "rcoder.coding" is not defined

--- a/R/linking.R
+++ b/R/linking.R
@@ -42,7 +42,11 @@ link_codings <- function(to, ..., .to_suffix = "to", .drop_unused = TRUE) {
   to_dat <- as.data.frame(to, suffix = .to_suffix)
 
   if (nrow(to_dat) < nrow(from_dat)) {
-    rc_err("Not all cases covered while linking codings.")
+    rc_err(c(
+      "Not all cases covered while linking codings. ",
+      "Access the `to` and `from` members of this error ",
+      "object to diagnose the issue."
+    ), to = to_dat, from = from_dat)
   }
 
   if (isTRUE(.drop_unused)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,10 +37,10 @@ cat_line <- function(x, .envir = parent.frame()) {
   cat(glue(x, .envir = .envir), "\n", sep = "")
 }
 
-rc_err <- function(x, .envir = parent.frame()) {
+rc_err <- function(x, .envir = parent.frame(), ...) {
   msg <- glue(glue_collapse(x), .envir = .envir)
 
-  rlang::abort(.subclass = "rc_error", message = msg)
+  rlang::abort(.subclass = "rc_error", message = msg, ...)
 }
 
 rc_assert <- function(x, msg = NULL, .envir = parent.frame()) {

--- a/tests/testthat/test-linking.R
+++ b/tests/testthat/test-linking.R
@@ -79,3 +79,24 @@ test_that("from only accepts a coding or list of codings", {
   expect_true(setequal(names(test_tbl_2), names(linked_all_indexed)))
   expect_true(setequal(linked_all_indexed, test_tbl_2))
 })
+
+test_that("Incomplete linking creates an informative error", {
+  coding_1 <- coding(
+    code("Yes", 1),
+    code("No", 0),
+    code("Not present", -99),
+    code("Refused", -88),
+    code("Don't know", -77)
+  )
+
+  coding_2 <- coding(
+    code("Yes", "YES"),
+    code("No", "NO"),
+    code("No response", "N/A")
+  )
+
+  err <- expect_error(link_codings(coding_2, coding_1))
+
+  expect_true(is.data.frame(err$to))
+  expect_true(is.data.frame(err$from))
+})


### PR DESCRIPTION
* Adds `to` and `from` members to incomplete linking error object to assist users in diagnosing errors