### PR TITLE
More informative errors and stricter linking requirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcoder
 Type: Package
 Title: Lightweight Data Structure for Recoding Categorical Data without Factors
-Version: 0.1.4.9000
+Version: 0.2.0
 Authors@R: 
     c(person(
             given = "Patrick", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcoder
 Type: Package
 Title: Lightweight Data Structure for Recoding Categorical Data without Factors
-Version: 0.1.4
+Version: 0.1.4.9000
 Authors@R: 
     c(person(
             given = "Patrick", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# rcoder 0.2.0
+
+* `link_codings` now doesn't drop unused links by default, preferring to error out instead
+* `link_codings(.drop_unused)` now signals to drop any links in `from` that aren't captured in `to`, harmonizing information flow
+* `as.character.coding` now doesn't include `links_from` by default. If you'd like to include that, use `as.character(include_links_from = TRUE)`
+* Missing `value` statements to `code()` now are reported in error message for better debugging experience
+
 # rcoder 0.1.4
 
 * Adds `to` and `from` members to incomplete linking error object for end-user diagnostics

--- a/R/code.R
+++ b/R/code.R
@@ -20,6 +20,13 @@ code <- function(label,
                  links_from = label,
                  missing = FALSE,
                  ...) {
+  if (missing(value)) {
+    rc_err(c(
+      "No value provided to label {ui_value(label)}. ",
+      "Probably caused by forgetting the second argument to code()"
+    ))
+  }
+
   rc_assert(
     is.character(label),
     "label ({ui_value(label)}) has type {ui_value(typeof(label))} when it should be 'character'."

--- a/R/coding.R
+++ b/R/coding.R
@@ -139,13 +139,11 @@ coding_label <- function(coding) {
 }
 
 #' @export
-as.data.frame.coding <- function(
-  x,
-  row.names = NULL,
-  optional = NULL,
-  suffix = NULL,
-  ...
-) {
+as.data.frame.coding <- function(x,
+                                 row.names = NULL,
+                                 optional = NULL,
+                                 suffix = NULL,
+                                 ...) {
   out <- coding_contents(x)
 
   if (!is.null(suffix)) {
@@ -176,7 +174,7 @@ print.coding <- function(x, ...) {
 }
 
 #' @export
-as.character.coding <- function(x, ...) {
+as.character.coding <- function(x, include_links_from = FALSE, ...) {
   code_calls <- lapply(x, function(code) {
     if (is.integer(code$value)) {
       code$value <- as.numeric(code$value)
@@ -188,8 +186,8 @@ as.character.coding <- function(x, ...) {
       cmd[["missing"]] <- TRUE
     }
 
-    if (!identical(code$links_from, code$label)) {
-      cmd[["links_from"]] <- code$links_from
+    if (!identical(code$links_from, code$label) && isTRUE(include_links_from)) {
+      cmd[["links_from"]] <- rlang::call2("c", !!!code$links_from)
     }
 
     if (!identical(code$description, code$label)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,7 +40,7 @@ cat_line <- function(x, .envir = parent.frame()) {
 rc_err <- function(x, .envir = parent.frame(), ...) {
   msg <- glue(glue_collapse(x), .envir = .envir)
 
-  rlang::abort(.subclass = "rc_error", message = msg, ...)
+  rlang::abort(message = msg, class = "rc_error", ...)
 }
 
 rc_assert <- function(x, msg = NULL, .envir = parent.frame()) {

--- a/man/link_codings.Rd
+++ b/man/link_codings.Rd
@@ -4,7 +4,7 @@
 \alias{link_codings}
 \title{Link a coding from others for recoding}
 \usage{
-link_codings(to, ..., .to_suffix = "to", .drop_unused = TRUE)
+link_codings(to, ..., .to_suffix = "to", .drop_unused = FALSE)
 }
 \arguments{
 \item{to}{A coding to be linked to}
@@ -14,8 +14,8 @@ link_codings(to, ..., .to_suffix = "to", .drop_unused = TRUE)
 \item{.to_suffix}{A suffix signifying which columns in the output `data.frame`
 came from `to`}
 
-\item{.drop_unused}{Logical flag to drop any codes in `to` that have no
-counterparts in `...`}
+\item{.drop_unused}{Logical flag to drop any codes in `...` that have no
+counterparts in `to`}
 }
 \value{
 A `linked_coding_df` with all necessary information for a recoding

--- a/tests/testthat/helper-errors.R
+++ b/tests/testthat/helper-errors.R
@@ -1,0 +1,3 @@
+expect_rc_error <- function(object, ...) {
+  expect_error(object, class = "rc_error", ...)
+}

--- a/tests/testthat/test-code.R
+++ b/tests/testthat/test-code.R
@@ -15,14 +15,39 @@ test_that("code definitions are consistent", {
 })
 
 test_that("coding creation makes sense", {
-    expect_identical(coding(), structure(list(), class = "coding", labels = integer()))
-    expect_rc_error(coding("Yes", 1))
-    expect_rc_error(coding(code("Yes", "Yes"), code("No", 1)))
-    expect_rc_error(coding(code("Yes", 1), code("Yes", 0)))
+  expect_identical(coding(), structure(list(), class = "coding", labels = integer()))
+  expect_rc_error(coding("Yes", 1))
+  expect_rc_error(coding(code("Yes", "Yes"), code("No", 1)))
+  expect_rc_error(coding(code("Yes", 1), code("Yes", 0)))
 })
 
 test_that("Safe coding evaluation works", {
   expr <- bquote(coding(code("Yes", 1), code("No", 2)))
 
   expect_identical(eval_coding(expr), coding(code("Yes", 1), code("No", 2)))
+})
+
+test_that("coding string representation works", {
+  coding_chr <- "coding(code(\"Yes\", 1), code(\"No\", 0))"
+  expect_identical(
+    as.character(coding(code("Yes", 1), code("No", 0))),
+    coding_chr
+  )
+
+  # Handling links_from deparsing
+  coding_chr <- "coding(code(\"Yes\", 1), code(\"No\", 0), code(\"Not available\", NA, missing = TRUE, links_from = c(\"Missing\", \"Refused\")))" # nolint
+  coding_chr1 <- "coding(code(\"Yes\", 1), code(\"No\", 0), code(\"Not available\", NA, missing = TRUE))" # nolint
+  expect_identical(
+    as.character(
+      coding(code("Yes", 1), code("No", 0), code("Not available", NA, links_from = c("Missing", "Refused"))), # nolint
+      include_links_from = TRUE
+    ),
+    coding_chr
+  )
+
+  # Ignore links_from by default
+  expect_identical(
+    as.character(coding(code("Yes", 1), code("No", 0), code("Not available", NA, links_from = c("Missing", "Refused")))), # nolint
+    coding_chr1
+  )
 })

--- a/tests/testthat/test-code.R
+++ b/tests/testthat/test-code.R
@@ -1,9 +1,5 @@
 context("Coding")
 
-expect_rc_error <- function(object, ...) {
-  expect_error(object, class = "rc_error", ...)
-}
-
 test_that("code definitions are consistent", {
   expect_rc_error(code(1, 1))
   expect_rc_error(code(1, 1, description = 1))

--- a/tests/testthat/test-linking.R
+++ b/tests/testthat/test-linking.R
@@ -12,10 +12,10 @@ test_that("No found links trigger an error", {
   )
 
   err <- expect_error(link_codings(coding_to, coding_from))
-  expect_true(grepl("^No common links", err$message))
+  expect_true(grepl("^Some links", err$message))
 
   err2 <- expect_error(link_codings(coding_to, coding_from, coding_from))
-  expect_true(grepl("^No common links", err2$message))
+  expect_true(grepl("^Some links", err2$message))
 })
 
 test_that("from only accepts a coding or list of codings", {
@@ -53,8 +53,9 @@ test_that("from only accepts a coding or list of codings", {
 
   test_tbl <- dplyr::tribble(
     ~link, ~label_to, ~value_to, ~label_1, ~value_1,
-    "Don't know", "Missing", NA, "Don't know",  -77,
+    "Don't know", "Missing", NA, "Don't know", -77,
     "No", "No", 0, "No", 0,
+    "No response", "Missing", NA, NA, NA,
     "Not present", "Missing", NA, "Not present", -99,
     "Refused", "Missing", NA, "Refused", -88,
     "Yes", "Yes", 1, "Yes", 1
@@ -67,7 +68,7 @@ test_that("from only accepts a coding or list of codings", {
 
   test_tbl_2 <- dplyr::tribble(
     ~link, ~label_to, ~value_to, ~label_1, ~value_1, ~label_2, ~value_2,
-    "Don't know", "Missing", NA, "Don't know",  -77, NA, NA,
+    "Don't know", "Missing", NA, "Don't know", -77, NA, NA,
     "No", "No", 0, "No", 0, "No", "NO",
     "No response", "Missing", NA, NA, NA, "No response", "N/A",
     "Not present", "Missing", NA, "Not present", -99, NA, NA,
@@ -99,4 +100,23 @@ test_that("Incomplete linking creates an informative error", {
 
   expect_true(is.data.frame(err$to))
   expect_true(is.data.frame(err$from))
+
+  # Issue encountered in a project
+  homogenized_coding <- coding(
+    code("Nearly everyday", 3),
+    code("More than half the days", 2),
+    code("A few days", 1),
+    code("Not at all", 0)
+  )
+
+  wave_coding <- coding(
+    code("Nearly everyday", 3),
+    code("More than half the days", 2),
+    code("A few days", 1),
+    code("No days", 0)
+  )
+
+  err <- expect_rc_error(link_codings(homogenized_coding, wave_coding))
+
+  expect_identical(err$missing_links, "No days")
 })


### PR DESCRIPTION
**Includes breaking changes!** Version bump to be consistent.

* `link_codings` now doesn't drop unused links by default, preferring to error out instead
* `link_codings(.drop_unused)` now signals to drop any links in `from` that aren't captured in `to`, harmonizing information flow
* `as.character.coding` now doesn't include `links_from` by default. If you'd like to include that, use `as.character(include_links_from = TRUE)`
* Missing `value` statements to `code()` now are reported in error message for better debugging experience