### PR TITLE
fix: deparse very long codings correctly

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,10 +1,8 @@
 on:
   push:
-    branches:
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - master
+    branches: [main, master]
 
 name: R-CMD-check
 
@@ -18,67 +16,32 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest,   r: 'release'}
-          # - {os: macOS-latest,   r: 'devel'}
-          - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '4.0', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.5', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        env:
-          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
-        run: |
-          Rscript -e "remotes::install_github('r-hub/sysreqs')"
-          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
-          sudo -s eval "$sysreqs"
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@master
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcoder
 Type: Package
 Title: Lightweight Data Structure for Recoding Categorical Data without Factors
-Version: 0.2.2
+Version: 0.2.3
 Authors@R: 
     c(person(
             given = "Patrick", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# rcoder 0.2.3
+* Fixes issue where coding deparsing could result in multi-length character vector
+
 # rcoder 0.2.2
 * Fixes issue where recoding would lose attributes of recoded vector
 

--- a/R/coding.R
+++ b/R/coding.R
@@ -214,6 +214,12 @@ as.character.coding <- function(x, include_links_from = FALSE, ...) {
   coding_call <- rlang::call2("coding", !!!code_calls)
   out <- rlang::expr_deparse(coding_call, width = 50000L)
 
+  # Sometimes there are very long codings, like a whole system's
+  # worth of schools. (2023-06-22)
+  if (length(out) > 1) {
+    out <- paste0(out, collapse = "")
+  }
+
   out
 }
 

--- a/tests/testthat/test-coding.R
+++ b/tests/testthat/test-coding.R
@@ -8,3 +8,21 @@ test_that("Coding selection works correctly", {
   expect_true(inherits(res, "coding"))
   expect_equivalent(res, coding(code("Missing", NA)))
 })
+
+test_that("Long codings get deparsed correctly", {
+  cdng <- lapply(1:1000, function(i) {
+    text <- paste0(
+      "Very long code ", i,
+      "that has tens of bytes in it which are unnecessary. ",
+      "This code text is insanely long and rarely useful."
+    )
+
+    code(text, text)
+  })
+
+  cdng <- do.call(coding, cdng)
+  cdng_chr <- as.character(cdng)
+
+  expect_true(length(cdng_chr) == 1L)
+  expect_true(nchar(cdng_chr) > 50000L)
+})


### PR DESCRIPTION
There is an internal limit of 50000 characters per deparse step. This gets around that older limit so that the character representation is always a string.
